### PR TITLE
Swift 5.0 branch tomswifty any

### DIFF
--- a/tools/driver/xamarinreflect_main.cpp
+++ b/tools/driver/xamarinreflect_main.cpp
@@ -620,14 +620,15 @@ private:
             _out << module->getFullName() << '.' << proto->getFullName();
         }
         else if (ty->getKind() == TypeKind::ProtocolComposition) {
-            // ProtocolComposition types (p: A & B) have the same issue as protocols. For whatever reason,
-            // the swift code doesn't print the fully qualified name.
-            ExistentialLayout layout = ty->getExistentialLayout();
-            printExistentialLayout (layout, optionalKind);
-        } else if (ty->isAny()) {
-            _out << "Swift.Any";
-        }
-        else {
+            if (ty->isAny()) {
+                _out << "Swift.Any";
+            } else {
+                // ProtocolComposition types (p: A & B) have the same issue as protocols. For whatever reason,
+                // the swift code doesn't print the fully qualified name.
+                ExistentialLayout layout = ty->getExistentialLayout();
+                printExistentialLayout (layout, optionalKind);
+            }
+        } else {
             visitPart(ty->getDesugaredType(), optionalKind);
         }
         

--- a/tools/driver/xamarinreflect_main.cpp
+++ b/tools/driver/xamarinreflect_main.cpp
@@ -624,6 +624,8 @@ private:
             // the swift code doesn't print the fully qualified name.
             ExistentialLayout layout = ty->getExistentialLayout();
             printExistentialLayout (layout, optionalKind);
+        } else if (ty->isAny()) {
+            _out << "Swift.Any";
         }
         else {
             visitPart(ty->getDesugaredType(), optionalKind);


### PR DESCRIPTION
It looks like the type `Swift.Any` is not it's own type but is a special case of the protocol composition type (an empty composition).

This explains why when the type was printed, it came out blank. I put in the test for `isAny` and that sorts out that problem.