### PR TITLE
Fixed missing terminal quote, made conformances have the full name, fixed a missing newline.

### DIFF
--- a/tools/driver/xamarinreflect_main.cpp
+++ b/tools/driver/xamarinreflect_main.cpp
@@ -325,7 +325,7 @@ private:
                     indents();
                     _out << "<superclass name=\"";
                     print(superClass, OTK_None);
-                    _out << "/>\n";
+                    _out << "\" />\n";
                 }
                 if (conformingProtos.size() > 0) {
                     indents();
@@ -334,7 +334,10 @@ private:
                     for (auto conformingProto : conformingProtos) {
                         indents();
                         _out << "<conformingprotocol name=\"";
-                        filterString(conformingProto->getName().str());
+                        auto name = conformingProto->getName().str();
+                        auto module = conformingProto->getModuleContext();
+                        _out << module->getFullName() << '.';
+                        filterString(name);
                         _out << "\"/>\n";
                     }
                     exdent();
@@ -349,7 +352,7 @@ private:
         
         exdent();
         indents();
-        _out << "</associatedtypes>";
+        _out << "</associatedtypes>\n";
     }
     
     // this is handy for debugging


### PR DESCRIPTION
Fixed 3 issues:
1. Missing a terminal `"` in superclass inheritance
2. Missing a terminal newline after `</associatedtypes>` tag
3. Made conformance output the module as well as the type.

Why was 3 necessary in the first place? Well - for some reason neither `getName()` nor `getFullName` return the full protocol name. As a result, we have to manually grab the module context and print that as well as the `.`