### PR TITLE
[cmake] Add support for exporting frameworks/libraries into cmake export files.

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -204,6 +204,13 @@ macro(add_sourcekit_library name)
     DESTINATION "include/SourceKit")
   set_target_properties(${name} PROPERTIES FOLDER "SourceKit libraries")
   add_sourcekit_default_compiler_flags("${name}")
+
+  swift_is_installing_component("${SOURCEKITLIB_INSTALL_IN_COMPONENT}" is_installing)
+  if(NOT is_installing)
+    set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
+  else()
+    set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
+  endif()
 endmacro()
 
 # Add a new SourceKit executable.
@@ -331,7 +338,6 @@ macro(add_sourcekit_framework name)
     endif()
   endif()
 
-
   if (SOURCEKIT_DEPLOYMENT_OS MATCHES "^macosx")
     swift_install_in_component(${SOURCEKITFW_INSTALL_IN_COMPONENT}
         TARGETS ${name}
@@ -372,6 +378,14 @@ macro(add_sourcekit_framework name)
         COMMAND ${CMAKE_COMMAND} -E copy "${hdr}" "${framework_location}/Headers/${hdrname}")
     endforeach()
   endif()
+
+  swift_is_installing_component("${SOURCEKITFW_INSTALL_IN_COMPONENT}" is_installing)
+  if(NOT is_installing)
+    set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
+  else()
+    set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
+  endif()
+
   add_sourcekit_default_compiler_flags("${name}")
 endmacro(add_sourcekit_framework)
 


### PR DESCRIPTION
This is a cherry pick of apple/swift@259afb2a567f7111fc692baa986f77d786999575 to work around this issue we ran into: https://forums.swift.org/t/cant-build-swift-5-1-toolchain/32403

---

I think this was just an oversight. The new cmake 3.16 seems to choke if we do
not add SourceKit to the exports file since there are dependencies upon it in
other swift libraries.

(cherry picked from commit 8d712af96575df088e98e5283a82fe891c8884b9)
