### PR TITLE
fixed various issues in subscripts and @escaping

### DIFF
--- a/tools/driver/xamarinreflect_main.cpp
+++ b/tools/driver/xamarinreflect_main.cpp
@@ -964,17 +964,12 @@ private:
         //        DeclName declName = AFD->getName();
         
         auto resultTy = getAbstractFunctionReturnType (AFD);
-//        auto ty = AFD->getDeclContext()->isTypeContext() ?
-//        AFD->getMethodInterfaceType() : AFD->getInterfaceType();
         
         AbstractStorageDecl *AD = nullptr;
         if (isa<AccessorDecl>(AFD)) {
             auto acc = cast<AccessorDecl>(AFD);
             AD = acc->getStorage();
         }
-        
-//        Type resultTy = ty->castTo<AnyFunctionType>()->getResult();
-//        resultTy = resultTy->getDesugaredType ();
         
         bool isDeprecated = AFD->getAttrs().getDeprecated(AFD->getASTContext());
         std::string flagAsDeprecated = isDeprecated ?

--- a/tools/driver/xamarinreflect_main.cpp
+++ b/tools/driver/xamarinreflect_main.cpp
@@ -268,7 +268,7 @@ private:
             indent();
             for (auto Elt : ED->getAllElements()) {
                 indents();
-                _out << "<element name=\"" << Elt->getName() << "\"";
+                _out << "<element name=\"" << Elt->getBaseIdentifier ().str () << "\"";
                 auto argTy = Elt->getArgumentInterfaceType();
                 if (argTy) {
                     _out << " type=\"";
@@ -504,43 +504,59 @@ private:
         }
     }
     
-    void visitVarDecl(VarDecl *VD)
+    void handleAbstractStorageDecl (AbstractStorageDecl *AD, bool isLet, bool isSubscript)
     {
         indents();
         
-        auto storageInfo = VD->getImplInfo();
-        AccessLevel effaccess = VD->getFormalAccess();
-        bool isDeprecated = VD->getAttrs().getDeprecated(VD->getASTContext());
-        bool isUnavailable = VD->getAttrs().getUnavailable(VD->getASTContext()) != nullptr;
-        bool isOptional = VD->getAttrs().getAttribute<OptionalAttr>() != 0;
+        auto storageInfo = AD->getImplInfo();
+        AccessLevel effaccess = AD->getFormalAccess();
+        bool isDeprecated = AD->getAttrs().getDeprecated(AD->getASTContext());
+        bool isUnavailable = AD->getAttrs().getUnavailable(AD->getASTContext()) != nullptr;
+        bool isOptional = AD->getAttrs().getAttribute<OptionalAttr>() != 0;
 
-        
-        _out << "<property name=\"" << VD->getName() << "\" type=\"";
-        
-        print(VD->getInterfaceType(), OTK_None);
-        
-        _out << "\" storage=\"" << ToString(storageInfo) << "\""
-        
-        << " accessibility=\"" << ToString(effaccess) << "\""
-        
-        << " isDeprecated=\"" << (isDeprecated ? "true\"" : "false\"")
-        
-        << " isUnavailable=\"" << (isUnavailable ? "true\"" : "false\"")
-        
-        << " isStatic=\"" << (VD->isStatic() ? "true\"" : "false\"")
-        
-        << " isLet=\"" << (VD->isLet() ? "true\"" : "false\"")
-        
-        << " isOptional=\"" << (isOptional ? "true\"" : "false\"")
-        
-        << " />\n";
+        Type type = AD->getAccessor(AccessorKind::Get) != nullptr ?
+            getAbstractFunctionReturnType(AD->getAccessor (AccessorKind::Get)) :
+            AD->getInterfaceType();
+            
+        auto name = isSubscript ? "subscript" : AD->getBaseIdentifier ().str ();
 
-    bool isComputed = storageInfo.getReadImpl() == ReadImplKind::Get;
-	if (!VD->getDeclContext()->isTypeContext() && isComputed && VD->getOpaqueAccessor(AccessorKind::Get) != nullptr) {
-                printAbstractFunction(VD->getOpaqueAccessor(AccessorKind::Get), false, false);
-                if (VD->getOpaqueAccessor(AccessorKind::Set) != nullptr)
-                        printAbstractFunction(VD->getOpaqueAccessor(AccessorKind::Set), false, false);
+        if (!isSubscript) {
+            _out << "<property name=\"" << name << "\" type=\"";
+            
+            print(type, OTK_None);
+            
+            _out << "\" storage=\"" << ToString(storageInfo) << "\""
+            
+            << " accessibility=\"" << ToString(effaccess) << "\""
+            
+            << " isDeprecated=\"" << (isDeprecated ? "true\"" : "false\"")
+            
+            << " isUnavailable=\"" << (isUnavailable ? "true\"" : "false\"")
+            
+            << " isStatic=\"" << (AD->isStatic() ? "true\"" : "false\"")
+            
+            << " isLet=\"" << (isLet ? "true\"" : "false\"")
+            
+            << " isOptional=\"" << (isOptional ? "true\"" : "false\"")
+            
+            << " />\n";
         }
+
+        if (AD->getAccessor(AccessorKind::Get) != nullptr) {
+                printAbstractFunction(AD->getAccessor(AccessorKind::Get), false, false);
+                if (AD->getAccessor(AccessorKind::Set) != nullptr)
+                        printAbstractFunction(AD->getAccessor(AccessorKind::Set), false, false);
+        }
+    }
+    
+    void visitVarDecl(VarDecl *VD)
+    {
+        handleAbstractStorageDecl (VD, VD->isLet (), false);
+    }
+    
+    void visitSubscriptDecl(SubscriptDecl *SD)
+    {
+        handleAbstractStorageDecl (SD, false, true);
     }
     
     
@@ -731,7 +747,11 @@ private:
                 print (param->getInterfaceType()->getInOutObjectType(), OTK_None);
             }
             else {
-                bool isEscaping = paramFlags.isNonEphemeral ();
+                bool isEscaping = false;
+                if (auto fType = param->getInterfaceType()->getAs<AnyFunctionType>()) {
+                    if (!fType->getExtInfo().isNoEscape())
+                        isEscaping = true;
+                }
                 // why square brackets, you might ask?
                 // It turns out that the language of attributes in swift is ambiguous.
                 // You can have
@@ -924,6 +944,15 @@ private:
             selStr = "subscript";
         return selStr;
     }
+    
+    Type getAbstractFunctionReturnType (AbstractFunctionDecl *AFD)
+    {
+        auto ty = AFD->getDeclContext()->isTypeContext() ?
+        AFD->getMethodInterfaceType() : AFD->getInterfaceType();
+        Type resultTy = ty->castTo<AnyFunctionType>()->getResult();
+        resultTy = resultTy->getDesugaredType ();
+        return resultTy;
+    }
 
     void printAbstractFunction(AbstractFunctionDecl *AFD, bool isClassMethod, bool isRequired) {
         
@@ -934,9 +963,9 @@ private:
         //        ObjCSelector sel = AFD->getObjCSelector();
         //        DeclName declName = AFD->getName();
         
-        
-        auto ty = AFD->getDeclContext()->isTypeContext() ?
-        AFD->getMethodInterfaceType() : AFD->getInterfaceType();
+        auto resultTy = getAbstractFunctionReturnType (AFD);
+//        auto ty = AFD->getDeclContext()->isTypeContext() ?
+//        AFD->getMethodInterfaceType() : AFD->getInterfaceType();
         
         AbstractStorageDecl *AD = nullptr;
         if (isa<AccessorDecl>(AFD)) {
@@ -944,8 +973,8 @@ private:
             AD = acc->getStorage();
         }
         
-        Type resultTy = ty->castTo<AnyFunctionType>()->getResult();
-        resultTy = resultTy->getDesugaredType ();
+//        Type resultTy = ty->castTo<AnyFunctionType>()->getResult();
+//        resultTy = resultTy->getDesugaredType ();
         
         bool isDeprecated = AFD->getAttrs().getDeprecated(AFD->getASTContext());
         std::string flagAsDeprecated = isDeprecated ?


### PR DESCRIPTION
Starting running reflector unit tests on this code base and had 18 failures, of which there were 4 unique problems:

- `getName` no longer returns a useful name in some cases. `getBaseIdentifier` now serves that purpose. For the curious, `getName` was returning ObjC style names in some cases. Weird flex, but OK.
- The AST visitor used to return a separate function declaration for property and subscript setters and getters for instance properties. This is no longer the case, so that simplifies the code.
- The AST visitor used to NOT have a subscript visitor (IIRC), it does now so we use it, but we don't generate a property to maintain compatibility with the old reflector
- `isEscaping` had gone away, but `isEphemeral` is not a 1:1 substitute. 