### PR TITLE
adding release/5.3-branch-tomswifty to update-checkout-config.json

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -305,6 +305,32 @@
                 "tensorflow-swift-apis": "master"
             }
         },
+        "release/5.3-branch-tomswifty": {
+            "aliases": ["release/5.3-branch-tomswifty", "swift/release/5.3-branch-tomswifty"],
+            "repos": {
+                "llvm-project": "swift/release/5.3-branch-tomswifty",
+                "swift": "release/5.3-branch-tomswifty",
+                "cmark": "release/5.3-branch-tomswifty",
+                "llbuild": "release/5.3-branch-tomswifty",
+                "swift-tools-support-core": "release/5.3-branch-tomswifty",
+                "swiftpm": "release/5.3-branch-tomswifty",
+                "swift-syntax": "release/5.3-branch-tomswifty",
+                "swift-stress-tester": "release/5.3-branch-tomswifty",
+                "swift-corelibs-xctest": "release/5.3-branch-tomswifty",
+                "swift-corelibs-foundation": "release/5.3-branch-tomswifty",
+                "swift-corelibs-libdispatch": "release/5.3-branch-tomswifty",
+                "swift-integration-tests": "release/5.3-branch-tomswifty",
+                "swift-xcode-playground-support": "release/5.3-branch-tomswifty",
+                "ninja": "release",
+                "icu": "release-65-1",
+                "cmake": "v3.16.5",
+                "indexstore-db": "release/5.3-branch-tomswifty",
+                "sourcekit-lsp": "release/5.3-branch-tomswifty",
+                "swift-format": "main",
+                "pythonkit": "main",
+                "tensorflow-swift-apis": "main"
+            }
+        },
        "master-rebranch": {
             "aliases": ["master-rebranch", "swift/master-rebranch"],
             "repos": {


### PR DESCRIPTION
Adding a part for 'release/5.3-branch-tomswifty' with swift-format pointing to 'main' since Apple closed their 'master' branch. 

Hoping to clear this error here while trying to build swift on binding-tools-for-swift pipeline: 
https://dev.azure.com/xamarin/public/_build/results?buildId=29182&view=logs&j=b944efd9-1a3a-54bf-926f-a01c570708bc&t=60778944-7c7a-5fea-4140-c14bb1e329d7