### PR TITLE
Changing default scheme to release/5.3-branch-tomswifty scheme

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -52,6 +52,7 @@
             "remote": { "id": "apple/llvm-project" } }
     },
     "default-branch-scheme": "master",
+    "release/5.3-branch-tomswifty-branch-scheme": "release/5.3-branch-tomswifty",
     "branch-schemes": {
        "master": {
             "aliases": ["master", "swift/master"],

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -571,7 +571,7 @@ repositories.
         # If branch is None, default to using the default branch alias
         # specified by our configuration file.
         if scheme is None:
-            scheme = config['default-branch-scheme']
+            scheme = config['release/5.3-branch-tomswifty-branch-scheme']
 
         skip_repo_list = skip_list_for_platform(config)
         skip_repo_list.extend(args.skip_repository_list)


### PR DESCRIPTION
I believe this is where the project is selecting master as the branch to use through the default-branch-scheme that uses the master branch. I want to point this to the release/5.3-branch-tomswifty scheme I created in the past PR (https://github.com/xamarin/binding-tools-for-swift-reflector/commit/a070653ba92e21cdae78837fc12c4383fdd58ee8) to use Apple's main branch instead of master to test building swift in the pipeline.