### PR TITLE
Implementing Rolf's suggestion to fix clang/math.h issue

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -693,11 +693,21 @@ class BuildScriptInvocation(object):
                     args.install_prefix),
                 "--host-lipo", toolchain.lipo,
             ]
+        
+        # TJ adding this from https://github.com/apple/swift/pull/33939/files
+        # To fix issue with clang/math.h.
+        # For additional isolation, disable pkg-config. Homebrew's pkg-config
+        # prioritizes CommandLineTools paths, resulting in compile errors.
+        args.extra_cmake_options += [
+            '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib',
+            '-DPKG_CONFIG_EXECUTABLE=/usr/bin/false',
+        ]
 
         if toolchain.libtool is not None:
             impl_args += [
                 "--host-libtool", toolchain.libtool,
             ]
+        # End of TJ edit
 
         # If we have extra_swift_args, combine all of them together and then
         # add them as one command.

--- a/utils/build-script
+++ b/utils/build-script
@@ -702,12 +702,12 @@ class BuildScriptInvocation(object):
             '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib',
             '-DPKG_CONFIG_EXECUTABLE=/usr/bin/false',
         ]
+        # End of TJ edit
 
         if toolchain.libtool is not None:
             impl_args += [
                 "--host-libtool", toolchain.libtool,
             ]
-        # End of TJ edit
 
         # If we have extra_swift_args, combine all of them together and then
         # add them as one command.


### PR DESCRIPTION
In this [PR](https://github.com/xamarin/binding-tools-for-swift/pull/505#discussion_r520678118) Rolf suggested to cherry-pick this change: https://github.com/apple/swift/pull/32436.

Towards the end of that PR, the author mentions a different fix that gives "better isolation" [here](https://github.com/apple/swift/pull/33939) and I implemented this one. Tried locally and it worked!

This will allow us not to have to modify Xcode files like I was doing [here](https://github.com/xamarin/binding-tools-for-swift/pull/505/commits/3264253de3374d2344346deef67145c01ed3073f#diff-e1e0fd28d8a090c1aa95cca1c1a7781655563b3f781b43a9ea8c1414c3fd6873L122)

I tried to cherry pick this change, but apple merged this change to their master branch that no longer shows up in apple/swift so I just implemented the change.
