### PR TITLE
Add operator declarations to reflection

### DIFF
--- a/tools/driver/xamarinreflect_main.cpp
+++ b/tools/driver/xamarinreflect_main.cpp
@@ -1116,7 +1116,8 @@ private:
             return;
         }
         auto infix = (InfixOperatorDecl *)op;
-        filterString(infix->getName().str());
+        auto group = op->getPrecedenceGroup ();
+        filterString(group->getName().str());
     }
     
 };

--- a/tools/driver/xamarinreflect_main.cpp
+++ b/tools/driver/xamarinreflect_main.cpp
@@ -1112,7 +1112,6 @@ private:
     void ToPrecedenceGroupName (OperatorDecl *op)
     {
         if (!isa<InfixOperatorDecl>(op)) {
-            _out << "\"None\"";
             return;
         }
         auto infix = (InfixOperatorDecl *)op;

--- a/tools/driver/xamarinreflect_main.cpp
+++ b/tools/driver/xamarinreflect_main.cpp
@@ -1116,7 +1116,7 @@ private:
             return;
         }
         auto infix = (InfixOperatorDecl *)op;
-        auto group = op->getPrecedenceGroup ();
+        auto group = infix->getPrecedenceGroup ();
         filterString(group->getName().str());
     }
     


### PR DESCRIPTION
Added code to generate operator declarations.
The general form is:
```
<operator name="xxxx" operatorKind="yyyy" precedenceGroup="zzzz" />
```

I refactored the code to get the operator kind as a string into its own method to reuse existing code. Note that this method already includes double quotes around the operator kind.

I chose not to include a precedence group declaration reflection (this allows you to create custom precedences for operators - for example, you could define vector operations and make cross product have higher precedence than dot product, but make them both, say, in the multiplicative precedence group). From the Biding Tools for Swift point of view, we don't need this nor do we need associativity nor do we need to know if the operator is assignment related. The reason being that all we care about is the front facing API and none of these are elements of the front facing API. They matter if you're compiling syntax that uses them but otherwise? Meh.
